### PR TITLE
Change to setting the Username field on the runtime spec for LCOW

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	runhcsoptions "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
@@ -36,13 +34,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/snapshots"
-	"github.com/davecgh/go-spew/spew"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
-	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
-	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-
 	"github.com/containerd/cri/pkg/annotations"
 	criconfig "github.com/containerd/cri/pkg/config"
 	customopts "github.com/containerd/cri/pkg/containerd/opts"
@@ -50,6 +41,13 @@ import (
 	cio "github.com/containerd/cri/pkg/server/io"
 	containerstore "github.com/containerd/cri/pkg/store/container"
 	"github.com/containerd/cri/pkg/util"
+	"github.com/davecgh/go-spew/spew"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // CreateContainer creates a new container in the given PodSandbox.
@@ -402,7 +400,8 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 			userstr = image.Config.User
 		}
 		if userstr != "" {
-			g.AddAnnotation("io.microsoft.lcow.userstr", userstr)
+			// For LCOW set the runtime specs Username field so we can take the user string and use this to find the uid:gid pair in the guest.
+			g.SetProcessUsername(userstr)
 		}
 		for _, group := range securityContext.GetSupplementalGroups() {
 			g.AddProcessAdditionalGid(uint32(group))


### PR DESCRIPTION
This change swaps to setting the Username field on the runtime spec for
the client provided user string for LCOW. This will make it easier to align with
upstream on a solution as setting an lcow annotation would be a bit odd there.
The string will be used in the same way in the guest, it will be parsed/validated
and the containers rootfs will be searched to find a uid:gid to set on the spec.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>