### PR TITLE
Support Linux container namespace options

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -421,7 +421,9 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 			return nil, err
 		}
 
-		setOCINamespaces(&g, securityContext.GetNamespaceOptions(), sandboxPid)
+		if err := setOCINamespaces(&g, securityContext.GetNamespaceOptions(), sandboxPid); err != nil {
+			return nil, err
+		}
 	} else {
 		resources := config.GetWindows().GetResources()
 		if resources != nil {


### PR DESCRIPTION
Previously the CRI namespace options were only used to determine if the
pid namespace should be shared with the pod or not. This expands the
support to allow use of pod/container/host modes for network/pid/ipc
namespaces.

This is of interest as it can allow a container to run in the host
network namespace so it can configure non-namespaced sysctl options,
such as those under net.core.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>