### PR TITLE
Add DisableSameLayerUnpack option to cri config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,13 @@ type ContainerdConfig struct {
 	// EnableLayerIntegrity is a boolean flag to specify whether to enable integrity
 	// protection of read-only container layers during image pull.
 	EnableLayerIntegrity bool `toml:"enable_layer_integrity" json:"enableLayerIntegrity"`
+
+	// DisableSameLayerUnpack changes the behavior when unpacking two or more of the
+	// same layers in parallel. If multiple snapshots are being made for the same layer,
+	// one will continue on to have a diff applied to it, and the other(s) will wait on the
+	// result of the first instead of all of them unpacking and the others simply getting garbage
+	// collected afterwards.
+	DisableSameLayerUnpack bool `toml:"disable_same_layer_unpack" json:"disableSameLayerUnpack"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -134,6 +134,11 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		pullOpts = append(pullOpts, containerd.WithLCOWLayerIntegrity())
 	}
 
+	if c.config.ContainerdConfig.DisableSameLayerUnpack {
+		pullOpts = append(pullOpts,
+			containerd.WithDisableSameLayerUnpack())
+	}
+
 	image, err := c.client.Pull(ctx, ref, pullOpts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to pull and unpack image %q", ref)


### PR DESCRIPTION
This change adds a new option named DisableSameLayerUnpack that stops Containerd from being able to unpack the same layer in parallel. This is most common if a pull of the same image is performed at the same time or different images that share layers being pulled at the same time.

This change relies on https://github.com/kevpar/containerd/pull/33 landing to make use of the containerd.WithDisableSameLayerUnpack() option so I've left it as a draft for now to avoid an accidental merge but this is free to review.