### PR TITLE
Enable integrity protection of LCOW layers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,10 @@ type ContainerdConfig struct {
 	// remove layers from the content store after successfully unpacking these
 	// layers to the snapshotter.
 	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers" json:"discardUnpackedLayers"`
+
+	// EnableLayerIntegrity is a boolean flag to specify whether to enable integrity
+	// protection of read-only container layers during image pull.
+	EnableLayerIntegrity bool `toml:"enable_layer_integrity" json:"enableLayerIntegrity"`
 }
 
 // CniConfig contains toml config related to cni

--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups caf71576c8b19daf80ab4685916e4d5b4c74887e
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd e21cab40ded910690883ee86e10ae7f7eaddf331 https://github.com/kevpar/containerd.git # fork/release/1.4
+github.com/containerd/containerd a449075834e97911116b5dcb19957fb7efd7ec4d https://github.com/kevpar/containerd.git # fork/release/1.4
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90

--- a/vendor/github.com/containerd/containerd/client_opts.go
+++ b/vendor/github.com/containerd/containerd/client_opts.go
@@ -19,6 +19,7 @@ package containerd
 import (
 	"time"
 
+	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
@@ -174,6 +175,12 @@ func WithPullLabels(labels map[string]string) RemoteOpt {
 		}
 		return nil
 	}
+}
+
+// WithLCOWLayerIntegrity enables integrity protection of LCOW layers by setting appropriate
+// RemoteContext label
+func WithLCOWLayerIntegrity() RemoteOpt {
+	return WithPullLabel(diff.LCOWLayerIntegrityEnabled, "true")
 }
 
 // WithChildLabelMap sets the map function used to define the labels set

--- a/vendor/github.com/containerd/containerd/diff/diff.go
+++ b/vendor/github.com/containerd/containerd/diff/diff.go
@@ -18,10 +18,18 @@ package diff
 
 import (
 	"context"
+	"strings"
 
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/typeurl"
 	"github.com/gogo/protobuf/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	LabelPrefix               = "containerd.io/diff/"
+	LCOWLayerIntegrityEnabled = LabelPrefix + "io.microsoft.lcow.append-dm-verity"
 )
 
 // Config is used to hold parameters needed for a diff operation
@@ -104,4 +112,46 @@ func WithPayloads(payloads map[string]*types.Any) ApplyOpt {
 		c.ProcessorPayloads = payloads
 		return nil
 	}
+}
+
+// WithStringPayloads marshals string values as types.Any and
+// sets/updates processor payloads
+func WithStringPayloads(labels map[string]string) ApplyOpt {
+	return func(_ context.Context, _ ocispec.Descriptor, c *ApplyConfig) error {
+		if labels == nil {
+			return nil
+		}
+
+		if c.ProcessorPayloads == nil {
+			c.ProcessorPayloads = make(map[string]*types.Any)
+		}
+
+		for k, v := range labels {
+			msg := &types.StringValue{
+				Value: v,
+			}
+			any, err := typeurl.MarshalAny(msg)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal string")
+			}
+			c.ProcessorPayloads[k] = any
+		}
+		return nil
+	}
+}
+
+// FilterDiffLabels filters the provided labels by removing any key which
+// isn't a diff label. Diff labels have a prefix of "containerd.io/diff/"
+func FilterDiffLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+
+	filtered := make(map[string]string)
+	for k, v := range labels {
+		if strings.HasPrefix(k, LabelPrefix) {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }

--- a/vendor/github.com/containerd/containerd/image.go
+++ b/vendor/github.com/containerd/containerd/image.go
@@ -286,6 +286,14 @@ type UnpackConfig struct {
 // UnpackOpt provides configuration for unpack
 type UnpackOpt func(context.Context, *UnpackConfig) error
 
+// WithUnpackConfigApplyOpts sets ApplyOpts for UnpackConfig
+func WithUnpackConfigApplyOpts(opts ...diff.ApplyOpt) UnpackOpt {
+	return func(_ context.Context, uc *UnpackConfig) error {
+		uc.ApplyOpts = append(uc.ApplyOpts, opts...)
+		return nil
+	}
+}
+
 func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...UnpackOpt) error {
 	ctx, done, err := i.client.WithLease(ctx)
 	if err != nil {

--- a/vendor/github.com/containerd/containerd/pull.go
+++ b/vendor/github.com/containerd/containerd/pull.go
@@ -19,6 +19,7 @@ package containerd
 import (
 	"context"
 
+	"github.com/containerd/containerd/diff"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
@@ -65,6 +66,13 @@ func (c *Client) Pull(ctx context.Context, ref string, opts ...RemoteOpt) (_ Ima
 	var unpacks int32
 	var unpackEg *errgroup.Group
 	var unpackWrapper func(f images.Handler) images.Handler
+
+	if pullCtx.Labels != nil {
+		diffLabels := diff.FilterDiffLabels(pullCtx.Labels)
+		if len(diffLabels) > 0 {
+			pullCtx.UnpackOpts = append(pullCtx.UnpackOpts, WithUnpackConfigApplyOpts(diff.WithStringPayloads(diffLabels)))
+		}
+	}
 
 	if pullCtx.Unpack {
 		// unpacker only supports schema 2 image, for schema 1 this is noop.

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -28,7 +28,7 @@ github.com/imdario/mergo                            v0.3.7
 github.com/konsorten/go-windows-terminal-sequences  v1.0.3
 github.com/matttproud/golang_protobuf_extensions    v1.0.1
 github.com/Microsoft/go-winio                       v0.4.14
-github.com/Microsoft/hcsshim                        v0.8.10
+github.com/Microsoft/hcsshim                        77c0270424049ab4c850c076601add11882e7c1e
 github.com/opencontainers/go-digest                 v1.0.0
 github.com/opencontainers/image-spec                v1.0.1
 github.com/opencontainers/runc                      v1.0.0-rc92


### PR DESCRIPTION
Revendor containerd fork to bring in LCOW layer integrity feature.
Add containerd config which enables layer integrity as well as
support enabling it on demand via an annotation.

Signed-off-by: Maksim An <maksiman@microsoft.com>