### PR TITLE
Update cri fork to use moby/sys signals

### DIFF
--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/containerd"
 	eventtypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
@@ -30,6 +29,7 @@ import (
 	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
 	"github.com/containerd/cri/pkg/store"
 	containerstore "github.com/containerd/cri/pkg/store/container"
+	"github.com/moby/sys/signal"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -134,12 +134,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			}
 		}
 
-		sandboxPlatform, err := c.getSandboxPlatform(container.Metadata.SandboxID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get container's sandbox platform")
-		}
-
-		sig, err := containerd.ParsePlatformSignal(stopSignal, sandboxPlatform)
+		sig, err := signal.ParseSignal(stopSignal)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse stop signal %q", stopSignal)
 		}

--- a/vendor.conf
+++ b/vendor.conf
@@ -35,6 +35,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/matttproud/golang_protobuf_extensions v1.0.0
 github.com/Microsoft/go-winio v0.4.16
 github.com/Microsoft/hcsshim d082725f6fc43269dd4adf659a3cd72e989c9783
+github.com/moby/sys 74ec3fe1325a016151d353bb6654d960042f9e96
 github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7

--- a/vendor/github.com/moby/sys/LICENSE
+++ b/vendor/github.com/moby/sys/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/moby/sys/signal/go.mod
+++ b/vendor/github.com/moby/sys/signal/go.mod
@@ -1,0 +1,5 @@
+module github.com/moby/sys/signal
+
+go 1.16
+
+require golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359

--- a/vendor/github.com/moby/sys/signal/signal.go
+++ b/vendor/github.com/moby/sys/signal/signal.go
@@ -1,0 +1,61 @@
+// Package signal provides helper functions for dealing with signals across
+// various operating systems.
+package signal
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// CatchAll catches all signals and relays them to the specified channel.
+// SIGURG is not handled, as it's used by the Go runtime to support
+// preemptable system calls.
+func CatchAll(sigc chan os.Signal) {
+	var handledSigs []os.Signal
+	for n, s := range SignalMap {
+		if n == "URG" {
+			// Do not handle SIGURG, as in go1.14+, the go runtime issues
+			// SIGURG as an interrupt to support preemptable system calls on Linux.
+			continue
+		}
+		handledSigs = append(handledSigs, s)
+	}
+	signal.Notify(sigc, handledSigs...)
+}
+
+// StopCatch stops catching the signals and closes the specified channel.
+func StopCatch(sigc chan os.Signal) {
+	signal.Stop(sigc)
+	close(sigc)
+}
+
+// ParseSignal translates a string to a valid syscall signal.
+// It returns an error if the signal map doesn't include the given signal.
+func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	s, err := strconv.Atoi(rawSignal)
+	if err == nil {
+		if s == 0 {
+			return -1, fmt.Errorf("invalid signal: %s", rawSignal)
+		}
+		return syscall.Signal(s), nil
+	}
+	signal, ok := SignalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
+	if !ok {
+		return -1, fmt.Errorf("invalid signal: %s", rawSignal)
+	}
+	return signal, nil
+}
+
+// ValidSignalForPlatform returns true if a signal is valid on the platform
+func ValidSignalForPlatform(sig syscall.Signal) bool {
+	for _, v := range SignalMap {
+		if v == sig {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/moby/sys/signal/signal_darwin.go
+++ b/vendor/github.com/moby/sys/signal/signal_darwin.go
@@ -1,0 +1,41 @@
+package signal
+
+import (
+	"syscall"
+)
+
+// SignalMap is a map of Darwin signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":   syscall.SIGABRT,
+	"ALRM":   syscall.SIGALRM,
+	"BUS":    syscall.SIGBUS,
+	"CHLD":   syscall.SIGCHLD,
+	"CONT":   syscall.SIGCONT,
+	"EMT":    syscall.SIGEMT,
+	"FPE":    syscall.SIGFPE,
+	"HUP":    syscall.SIGHUP,
+	"ILL":    syscall.SIGILL,
+	"INFO":   syscall.SIGINFO,
+	"INT":    syscall.SIGINT,
+	"IO":     syscall.SIGIO,
+	"IOT":    syscall.SIGIOT,
+	"KILL":   syscall.SIGKILL,
+	"PIPE":   syscall.SIGPIPE,
+	"PROF":   syscall.SIGPROF,
+	"QUIT":   syscall.SIGQUIT,
+	"SEGV":   syscall.SIGSEGV,
+	"STOP":   syscall.SIGSTOP,
+	"SYS":    syscall.SIGSYS,
+	"TERM":   syscall.SIGTERM,
+	"TRAP":   syscall.SIGTRAP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"URG":    syscall.SIGURG,
+	"USR1":   syscall.SIGUSR1,
+	"USR2":   syscall.SIGUSR2,
+	"VTALRM": syscall.SIGVTALRM,
+	"WINCH":  syscall.SIGWINCH,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+}

--- a/vendor/github.com/moby/sys/signal/signal_freebsd.go
+++ b/vendor/github.com/moby/sys/signal/signal_freebsd.go
@@ -1,0 +1,43 @@
+package signal
+
+import (
+	"syscall"
+)
+
+// SignalMap is a map of FreeBSD signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":   syscall.SIGABRT,
+	"ALRM":   syscall.SIGALRM,
+	"BUS":    syscall.SIGBUS,
+	"CHLD":   syscall.SIGCHLD,
+	"CONT":   syscall.SIGCONT,
+	"EMT":    syscall.SIGEMT,
+	"FPE":    syscall.SIGFPE,
+	"HUP":    syscall.SIGHUP,
+	"ILL":    syscall.SIGILL,
+	"INFO":   syscall.SIGINFO,
+	"INT":    syscall.SIGINT,
+	"IO":     syscall.SIGIO,
+	"IOT":    syscall.SIGIOT,
+	"KILL":   syscall.SIGKILL,
+	"LWP":    syscall.SIGLWP,
+	"PIPE":   syscall.SIGPIPE,
+	"PROF":   syscall.SIGPROF,
+	"QUIT":   syscall.SIGQUIT,
+	"SEGV":   syscall.SIGSEGV,
+	"STOP":   syscall.SIGSTOP,
+	"SYS":    syscall.SIGSYS,
+	"TERM":   syscall.SIGTERM,
+	"THR":    syscall.SIGTHR,
+	"TRAP":   syscall.SIGTRAP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"URG":    syscall.SIGURG,
+	"USR1":   syscall.SIGUSR1,
+	"USR2":   syscall.SIGUSR2,
+	"VTALRM": syscall.SIGVTALRM,
+	"WINCH":  syscall.SIGWINCH,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+}

--- a/vendor/github.com/moby/sys/signal/signal_linux.go
+++ b/vendor/github.com/moby/sys/signal/signal_linux.go
@@ -1,0 +1,84 @@
+//go:build !mips && !mipsle && !mips64 && !mips64le
+// +build !mips,!mipsle,!mips64,!mips64le
+
+package signal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sigrtmin = 34
+	sigrtmax = 64
+)
+
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":     unix.SIGABRT,
+	"ALRM":     unix.SIGALRM,
+	"BUS":      unix.SIGBUS,
+	"CHLD":     unix.SIGCHLD,
+	"CLD":      unix.SIGCLD,
+	"CONT":     unix.SIGCONT,
+	"FPE":      unix.SIGFPE,
+	"HUP":      unix.SIGHUP,
+	"ILL":      unix.SIGILL,
+	"INT":      unix.SIGINT,
+	"IO":       unix.SIGIO,
+	"IOT":      unix.SIGIOT,
+	"KILL":     unix.SIGKILL,
+	"PIPE":     unix.SIGPIPE,
+	"POLL":     unix.SIGPOLL,
+	"PROF":     unix.SIGPROF,
+	"PWR":      unix.SIGPWR,
+	"QUIT":     unix.SIGQUIT,
+	"SEGV":     unix.SIGSEGV,
+	"STKFLT":   unix.SIGSTKFLT,
+	"STOP":     unix.SIGSTOP,
+	"SYS":      unix.SIGSYS,
+	"TERM":     unix.SIGTERM,
+	"TRAP":     unix.SIGTRAP,
+	"TSTP":     unix.SIGTSTP,
+	"TTIN":     unix.SIGTTIN,
+	"TTOU":     unix.SIGTTOU,
+	"URG":      unix.SIGURG,
+	"USR1":     unix.SIGUSR1,
+	"USR2":     unix.SIGUSR2,
+	"VTALRM":   unix.SIGVTALRM,
+	"WINCH":    unix.SIGWINCH,
+	"XCPU":     unix.SIGXCPU,
+	"XFSZ":     unix.SIGXFSZ,
+	"RTMIN":    sigrtmin,
+	"RTMIN+1":  sigrtmin + 1,
+	"RTMIN+2":  sigrtmin + 2,
+	"RTMIN+3":  sigrtmin + 3,
+	"RTMIN+4":  sigrtmin + 4,
+	"RTMIN+5":  sigrtmin + 5,
+	"RTMIN+6":  sigrtmin + 6,
+	"RTMIN+7":  sigrtmin + 7,
+	"RTMIN+8":  sigrtmin + 8,
+	"RTMIN+9":  sigrtmin + 9,
+	"RTMIN+10": sigrtmin + 10,
+	"RTMIN+11": sigrtmin + 11,
+	"RTMIN+12": sigrtmin + 12,
+	"RTMIN+13": sigrtmin + 13,
+	"RTMIN+14": sigrtmin + 14,
+	"RTMIN+15": sigrtmin + 15,
+	"RTMAX-14": sigrtmax - 14,
+	"RTMAX-13": sigrtmax - 13,
+	"RTMAX-12": sigrtmax - 12,
+	"RTMAX-11": sigrtmax - 11,
+	"RTMAX-10": sigrtmax - 10,
+	"RTMAX-9":  sigrtmax - 9,
+	"RTMAX-8":  sigrtmax - 8,
+	"RTMAX-7":  sigrtmax - 7,
+	"RTMAX-6":  sigrtmax - 6,
+	"RTMAX-5":  sigrtmax - 5,
+	"RTMAX-4":  sigrtmax - 4,
+	"RTMAX-3":  sigrtmax - 3,
+	"RTMAX-2":  sigrtmax - 2,
+	"RTMAX-1":  sigrtmax - 1,
+	"RTMAX":    sigrtmax,
+}

--- a/vendor/github.com/moby/sys/signal/signal_linux_mipsx.go
+++ b/vendor/github.com/moby/sys/signal/signal_linux_mipsx.go
@@ -1,0 +1,85 @@
+//go:build linux && (mips || mipsle || mips64 || mips64le)
+// +build linux
+// +build mips mipsle mips64 mips64le
+
+package signal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sigrtmin = 34
+	sigrtmax = 127
+)
+
+// SignalMap is a map of Linux signals.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT":     unix.SIGABRT,
+	"ALRM":     unix.SIGALRM,
+	"BUS":      unix.SIGBUS,
+	"CHLD":     unix.SIGCHLD,
+	"CLD":      unix.SIGCLD,
+	"CONT":     unix.SIGCONT,
+	"FPE":      unix.SIGFPE,
+	"HUP":      unix.SIGHUP,
+	"ILL":      unix.SIGILL,
+	"INT":      unix.SIGINT,
+	"IO":       unix.SIGIO,
+	"IOT":      unix.SIGIOT,
+	"KILL":     unix.SIGKILL,
+	"PIPE":     unix.SIGPIPE,
+	"POLL":     unix.SIGPOLL,
+	"PROF":     unix.SIGPROF,
+	"PWR":      unix.SIGPWR,
+	"QUIT":     unix.SIGQUIT,
+	"SEGV":     unix.SIGSEGV,
+	"EMT":      unix.SIGEMT,
+	"STOP":     unix.SIGSTOP,
+	"SYS":      unix.SIGSYS,
+	"TERM":     unix.SIGTERM,
+	"TRAP":     unix.SIGTRAP,
+	"TSTP":     unix.SIGTSTP,
+	"TTIN":     unix.SIGTTIN,
+	"TTOU":     unix.SIGTTOU,
+	"URG":      unix.SIGURG,
+	"USR1":     unix.SIGUSR1,
+	"USR2":     unix.SIGUSR2,
+	"VTALRM":   unix.SIGVTALRM,
+	"WINCH":    unix.SIGWINCH,
+	"XCPU":     unix.SIGXCPU,
+	"XFSZ":     unix.SIGXFSZ,
+	"RTMIN":    sigrtmin,
+	"RTMIN+1":  sigrtmin + 1,
+	"RTMIN+2":  sigrtmin + 2,
+	"RTMIN+3":  sigrtmin + 3,
+	"RTMIN+4":  sigrtmin + 4,
+	"RTMIN+5":  sigrtmin + 5,
+	"RTMIN+6":  sigrtmin + 6,
+	"RTMIN+7":  sigrtmin + 7,
+	"RTMIN+8":  sigrtmin + 8,
+	"RTMIN+9":  sigrtmin + 9,
+	"RTMIN+10": sigrtmin + 10,
+	"RTMIN+11": sigrtmin + 11,
+	"RTMIN+12": sigrtmin + 12,
+	"RTMIN+13": sigrtmin + 13,
+	"RTMIN+14": sigrtmin + 14,
+	"RTMIN+15": sigrtmin + 15,
+	"RTMAX-14": sigrtmax - 14,
+	"RTMAX-13": sigrtmax - 13,
+	"RTMAX-12": sigrtmax - 12,
+	"RTMAX-11": sigrtmax - 11,
+	"RTMAX-10": sigrtmax - 10,
+	"RTMAX-9":  sigrtmax - 9,
+	"RTMAX-8":  sigrtmax - 8,
+	"RTMAX-7":  sigrtmax - 7,
+	"RTMAX-6":  sigrtmax - 6,
+	"RTMAX-5":  sigrtmax - 5,
+	"RTMAX-4":  sigrtmax - 4,
+	"RTMAX-3":  sigrtmax - 3,
+	"RTMAX-2":  sigrtmax - 2,
+	"RTMAX-1":  sigrtmax - 1,
+	"RTMAX":    sigrtmax,
+}

--- a/vendor/github.com/moby/sys/signal/signal_unix.go
+++ b/vendor/github.com/moby/sys/signal/signal_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+// +build !windows
+
+package signal
+
+import (
+	"syscall"
+)
+
+// Signals used in cli/command (no windows equivalent, use
+// invalid signals so they don't get handled)
+
+const (
+	// SIGCHLD is a signal sent to a process when a child process terminates, is interrupted, or resumes after being interrupted.
+	SIGCHLD = syscall.SIGCHLD
+	// SIGWINCH is a signal sent to a process when its controlling terminal changes its size
+	SIGWINCH = syscall.SIGWINCH
+	// SIGPIPE is a signal sent to a process when a pipe is written to before the other end is open for reading
+	SIGPIPE = syscall.SIGPIPE
+)

--- a/vendor/github.com/moby/sys/signal/signal_unsupported.go
+++ b/vendor/github.com/moby/sys/signal/signal_unsupported.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin && !freebsd && !windows
+// +build !linux,!darwin,!freebsd,!windows
+
+package signal
+
+import (
+	"syscall"
+)
+
+// SignalMap is an empty map of signals for unsupported platform.
+var SignalMap = map[string]syscall.Signal{}

--- a/vendor/github.com/moby/sys/signal/signal_windows.go
+++ b/vendor/github.com/moby/sys/signal/signal_windows.go
@@ -1,0 +1,57 @@
+package signal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// Signals used in cli/command (no windows equivalent, use
+// invalid signals so they don't get handled)
+const (
+	SIGCHLD  = syscall.Signal(0xff)
+	SIGWINCH = syscall.Signal(0xff)
+	SIGPIPE  = syscall.Signal(0xff)
+)
+
+// SignalMap is a map of "supported" signals. As per the comment in GOLang's
+// ztypes_windows.go: "More invented values for signals". Windows doesn't
+// really support signals in any way, shape or form that Unix does.
+var SignalMap = map[string]syscall.Signal{
+	"ABRT": syscall.Signal(windows.SIGABRT),
+	"ALRM": syscall.Signal(windows.SIGALRM),
+	"BUS":  syscall.Signal(windows.SIGBUS),
+	"FPE":  syscall.Signal(windows.SIGFPE),
+	"HUP":  syscall.Signal(windows.SIGHUP),
+	"ILL":  syscall.Signal(windows.SIGILL),
+	"INT":  syscall.Signal(windows.SIGINT),
+	"KILL": syscall.Signal(windows.SIGKILL),
+	"PIPE": syscall.Signal(windows.SIGPIPE),
+	"QUIT": syscall.Signal(windows.SIGQUIT),
+	"SEGV": syscall.Signal(windows.SIGSEGV),
+	"TERM": syscall.Signal(windows.SIGTERM),
+	"TRAP": syscall.Signal(windows.SIGTRAP),
+
+	// additional linux signals supported for LCOW
+	"CHLD":   syscall.Signal(0x11),
+	"CLD":    syscall.Signal(0x11),
+	"CONT":   syscall.Signal(0x12),
+	"IO":     syscall.Signal(0x1d),
+	"IOT":    syscall.Signal(0x6),
+	"POLL":   syscall.Signal(0x1d),
+	"PROF":   syscall.Signal(0x1b),
+	"PWR":    syscall.Signal(0x1e),
+	"STKFLT": syscall.Signal(0x10),
+	"STOP":   syscall.Signal(0x13),
+	"SYS":    syscall.Signal(0x1f),
+	"TSTP":   syscall.Signal(0x14),
+	"TTIN":   syscall.Signal(0x15),
+	"TTOU":   syscall.Signal(0x16),
+	"URG":    syscall.Signal(0x17),
+	"USR1":   syscall.Signal(0xa),
+	"USR2":   syscall.Signal(0xc),
+	"VTALRM": syscall.Signal(0x1a),
+	"WINCH":  syscall.Signal(0x1c),
+	"XCPU":   syscall.Signal(0x18),
+	"XFSZ":   syscall.Signal(0x19),
+}


### PR DESCRIPTION
This PR updates our CRI fork to use the work in https://github.com/moby/sys/pull/98 to allow us to support signals for LCOW 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>