### PR TITLE
Add +build tags as well to fix nightly builds

### DIFF
--- a/pkg/server/container_reset_unix.go
+++ b/pkg/server/container_reset_unix.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/server/container_reset_windows.go
+++ b/pkg/server/container_reset_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/server/sandbox_reset_unix.go
+++ b/pkg/server/sandbox_reset_unix.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 /*
 Copyright 2017 The Kubernetes Authors.
@@ -19,10 +20,9 @@ limitations under the License.
 package server
 
 import (
-	api "github.com/containerd/cri/pkg/api/v1"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func (c *criService) resetSandbox(ctx context.Context, sandbox sandboxstore.Sandbox) (retErr error) {

--- a/pkg/server/sandbox_reset_windows.go
+++ b/pkg/server/sandbox_reset_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.


### PR DESCRIPTION
CI uses go version < 1.17 and missing +build tag breaks builds.
Remove unused import as well.

Signed-off-by: Maksim An <maksiman@microsoft.com>