### PR TITLE
Shortterm fix to bundle delete failing

### DIFF
--- a/pkg/server/sandbox_stop_windows.go
+++ b/pkg/server/sandbox_stop_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -20,10 +21,15 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/plugin"
 	"github.com/pkg/errors"
 
+	"github.com/containerd/cri/pkg/constants"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
@@ -44,6 +50,22 @@ func (c *criService) doStopPodSandbox(ctx context.Context, id string, sandbox sa
 	}
 
 	log.G(ctx).Infof("TearDown network for sandbox %q successfully", id)
+
+	// TODO: remove this when retry logic is added to Bundle.Delete in upstream containerd
+	// There is a race condition if hcsshim does not exit early for the lock on the bundle path
+	// (its working directory) to be release in time for contaienrd  to successfully delete the
+	// bundle during
+	// "github.com/containerd/containerd/containerd/runtime/v2/".shim.Delete()
+	// Even if the shim exits before the delete opteration, it may take several milliseconds for
+	// the OS to flush that change.
+	// Delete the bundle if it still exits to ensure propper cleanup
+	bp := filepath.Join(filepath.Dir(c.config.StateDir),
+		fmt.Sprintf("%s.%s", plugin.RuntimePluginV2, "task"), // from "github.com/containerd/containerd/runtime/v2".TaskManager{}.ID()
+		constants.K8sContainerdNamespace,
+		id)
+	if err := os.RemoveAll(bp); err != nil { // does not error if path is nonexistant
+		log.G(ctx).WithError(err).Warning("could not remove bundle path")
+	}
 
 	return nil
 


### PR DESCRIPTION
`Bundle.Delete` fails because the OS does not remove the lock on the
bundle path early enough when the shim exits for the delete to succeed.

This adds a `RemoveAll` to ensure the Bundle is properly deleted after
all the pod stop logic is completed.

Signed-off-by: Hamza El-Saawy <hamzaelsaawy@microsoft.com>