### PR TITLE
Remove reference to a nonexistent package

### DIFF
--- a/pkg/server/sandbox_run_unix.go
+++ b/pkg/server/sandbox_run_unix.go
@@ -39,7 +39,6 @@ import (
 	criconfig "github.com/containerd/cri/pkg/config"
 	customopts "github.com/containerd/cri/pkg/containerd/opts"
 	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
-	"github.com/containerd/cri/pkg/log"
 	"github.com/containerd/cri/pkg/netns"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 	"github.com/containerd/cri/pkg/util"


### PR DESCRIPTION
Even though this PR is for a *_unix.go file, this change is necessary as part of the work to move to building our cri fork from our containerd fork. Without this change, vendoring in cri to our containerd fork causes an error. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>