### PR TITLE
Revert "Remove gogo protobuf type for events"

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
 	"github.com/containerd/typeurl"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -134,7 +135,7 @@ func (em *eventMonitor) startExitMonitor(ctx context.Context, id string, pid uin
 	return stopCh
 }
 
-func convertEvent(e typeurl.Any) (string, interface{}, error) {
+func convertEvent(e *gogotypes.Any) (string, interface{}, error) {
 	id := ""
 	evt, err := typeurl.UnmarshalAny(e)
 	if err != nil {


### PR DESCRIPTION
This reverts commit fe18db43f8fe56d34bcbbb1d7e56ae8e5c6dadcd.

We update the events type used in our cri fork here so we could be in lock step with contained release 1.6's code changes. However, we currently rely on the gogo protobuf type in our containerd fork for use with integrity checking for LCOW layers (see [here](https://github.com/kevpar/containerd/commit/2587ab8dc34299208519240a03fa3383959d8725)). 

We probably want to update the code mentioned above for integrity checking, but since we likely would want to do some testing and validation that nothing breaks, this PR reverts back to the gogo protobuf types for events so we can build the repo again. 
